### PR TITLE
Refactor App into Python Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Arguments:
 Options:
   -d, --directory TEXT  The directory in which to create the component.
                         [default: src/components/]
+  -e, --extension TEXT  The file extension for the created component files.
+                        [default: js]
   -v, --version         Show the application's version and exit.
   --install-completion  Install completion for the current shell.
   --show-completion     Show completion for the current shell, to copy it or

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ Arguments:
 Options:
   -d, --directory TEXT  The directory in which to create the component.
                         [default: src/components/]
+  -e, --extension TEXT  The file extension for the created component files.
+                        [default: js]
   -v, --version         Show the application's version and exit.
   --install-completion  Install completion for the current shell.
   --show-completion     Show completion for the current shell, to copy it or

--- a/new_component/_constants.py
+++ b/new_component/_constants.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+import new_component
+
+INSTALLED_LOCATION = new_component.__file__
+TEMPLATES_DIR = INSTALLED_LOCATION.replace("__init__.py", "")
+TEMPLATES_PATH = Path(TEMPLATES_DIR) / "templates"

--- a/new_component/_echos.py
+++ b/new_component/_echos.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import typer
+
+
+def _create_new_component_echo(
+    component_name: str, full_path_to_component_directory: Path
+) -> None:
+    """
+    Echos the newly created component and directory.
+    """
+
+    message_start = "Created a new "
+    component = typer.style(component_name, fg=typer.colors.GREEN, bold=True)
+    message_end = " Component 💅 🚀!"
+    new_directory_path = typer.style(
+        full_path_to_component_directory, fg=typer.colors.GREEN, bold=True
+    )
+    message = message_start + component + message_end
+    typer.echo(message)
+    typer.echo(new_directory_path)
+
+
+def _create_components_dir_echo(components_directory: Path) -> None:
+    message = f"Warning: created the {components_directory} directory."
+    styled_message = typer.style(message, fg=typer.colors.YELLOW, bold=True)
+    typer.echo(styled_message)

--- a/new_component/_jinja.py
+++ b/new_component/_jinja.py
@@ -1,0 +1,12 @@
+from jinja2 import Environment, FileSystemLoader
+
+from new_component._constants import TEMPLATES_PATH
+
+
+def _create_jinja_environment() -> Environment:
+    """
+    Creates the Jinja Environment with the path to the package's templates
+    """
+    # typer.echo(TEMPLATES_PATH)
+    loader = FileSystemLoader(TEMPLATES_PATH)
+    return Environment(loader=loader)

--- a/new_component/_utils.py
+++ b/new_component/_utils.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def _create_directory(directory: Path, parents: bool = True) -> None:
+    if directory.exists() is False:
+        directory.mkdir(
+            parents=parents  # create missing parent folders
+        )  # Create directory

--- a/new_component/_version.py
+++ b/new_component/_version.py
@@ -1,0 +1,9 @@
+import typer
+
+from new_component import __app_name__, __version__
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"{__app_name__} v{__version__}")
+        raise typer.Exit()

--- a/new_component/cli.py
+++ b/new_component/cli.py
@@ -11,23 +11,28 @@ from new_component._version import _version_callback
 app = typer.Typer()
 
 DEFAULT_COMPONENTS_DIR = "src/components/"
+DEFAULT_FILE_EXTENSION = "js"  # jsx, ts, etc.
 JINJA_ENVIRONMENT = _create_jinja_environment()
 
 
 def _create_output(
-    new_directory: Path, template_name: str, variables: dict, filename: str = None
+    new_directory: Path,
+    template_name: str,
+    variables: dict,
+    extension: str,
+    filename: str = None,
 ) -> None:
     """
     Write new file to disk, within `new_directory`,
     by rendering the jinja template `template_name`
     """
     if filename is None:
-        filename = template_name.replace(".j2", "")
+        filename = template_name
 
-    template = JINJA_ENVIRONMENT.get_template(template_name)
+    template = JINJA_ENVIRONMENT.get_template(f"{template_name}.js.j2")
     output = template.render(variables)
 
-    with open(f"{new_directory}/{filename}", "w") as f:
+    with open(f"{new_directory}/{filename}.{extension}", "w") as f:
         f.write(output)
 
 
@@ -42,6 +47,12 @@ def main(
         "--directory",
         "-d",
         help="The directory in which to create the component.",
+    ),
+    extension: str = typer.Option(
+        DEFAULT_FILE_EXTENSION,
+        "--extension",
+        "-e",
+        help="The file extension for the created component files.",
     ),
     version: Optional[bool] = typer.Option(
         None,
@@ -92,14 +103,16 @@ def main(
     # Render component files in your components directory
     _create_output(
         new_directory=full_path_to_component_directory,
-        template_name="index.js.j2",
+        template_name="index",
         variables=variables,
+        extension=extension,
     )
     _create_output(
         new_directory=full_path_to_component_directory,
-        template_name="component.js.j2",
+        template_name="component",
         variables=variables,
-        filename=f"{name}.js",
+        extension=extension,
+        filename=f"{name}",
     )
 
     # Echo status to user

--- a/new_component/cli.py
+++ b/new_component/cli.py
@@ -3,18 +3,32 @@ from typing import Optional
 
 import typer
 
-import new_component
-from new_component import __app_name__, __version__
+from new_component._echos import _create_components_dir_echo, _create_new_component_echo
+from new_component._jinja import _create_jinja_environment
+from new_component._utils import _create_directory
+from new_component._version import _version_callback
 
 app = typer.Typer()
 
-__COMPONENTS_DIR__ = "src/components/"
+DEFAULT_COMPONENTS_DIR = "src/components/"
+JINJA_ENVIRONMENT = _create_jinja_environment()
 
 
-def _version_callback(value: bool) -> None:
-    if value:
-        typer.echo(f"{__app_name__} v{__version__}")
-        raise typer.Exit()
+def _create_output(
+    new_directory: Path, template_name: str, variables: dict, filename: str = None
+) -> None:
+    """
+    Write new file to disk, within `new_directory`,
+    by rendering the jinja template `template_name`
+    """
+    if filename is None:
+        filename = template_name.replace(".j2", "")
+
+    template = JINJA_ENVIRONMENT.get_template(template_name)
+    output = template.render(variables)
+
+    with open(f"{new_directory}/{filename}", "w") as f:
+        f.write(output)
 
 
 @app.command()
@@ -24,7 +38,7 @@ def main(
         help="Name of component to create.",
     ),
     directory: str = typer.Option(
-        __COMPONENTS_DIR__,
+        DEFAULT_COMPONENTS_DIR,
         "--directory",
         "-d",
         help="The directory in which to create the component.",
@@ -46,43 +60,50 @@ def main(
     """
 
     components_directory = Path(directory)
-    new_directory = components_directory / name
 
-    if new_directory.exists() is False:
-        new_directory.mkdir(
-            parents=True
-        )  # Create directory, creating missing parent folders
+    if components_directory.exists() is False:
+        # Could set creation with a variable
+        _create_directory(directory=components_directory)
+        _create_components_dir_echo(components_directory=components_directory)
 
-    # index_file = new_directory / "index.js"
+    new_component_directory = components_directory / name
+    full_path_to_component_directory = Path.cwd() / new_component_directory
 
-    new_directory_full_path = Path.cwd() / new_directory
-    message_start = "Created a new "
-    component = typer.style(name, fg=typer.colors.GREEN, bold=True)
-    message_end = " Component 💅 🚀!"
-    new_directory_path = typer.style(
-        new_directory_full_path, fg=typer.colors.GREEN, bold=True
+    # Allow user to abort if component already exists
+    if full_path_to_component_directory.exists() is True:
+        warning_message = (
+            f"{name} component already exists in ./{components_directory}/."
+        )
+        styled_warning = typer.style(warning_message, typer.colors.YELLOW, bold=True)
+        styled_component = typer.style(f"{name}", typer.colors.YELLOW, bold=True)
+        confirm_message = (
+            "Are you sure you want to overwrite your "
+            + styled_component
+            + " component?"
+        )
+        typer.echo(styled_warning)
+        typer.confirm(confirm_message, abort=True)
+    else:
+        _create_directory(directory=full_path_to_component_directory)
+
+    # Jinja Variables used in template render
+    variables = {"ComponentName": name}
+
+    # Render component files in your components directory
+    _create_output(
+        new_directory=full_path_to_component_directory,
+        template_name="index.js.j2",
+        variables=variables,
     )
-    message = message_start + component + message_end
-    typer.echo(message)
-    typer.echo(new_directory_path)
+    _create_output(
+        new_directory=full_path_to_component_directory,
+        template_name="component.js.j2",
+        variables=variables,
+        filename=f"{name}.js",
+    )
 
-    installed_location = new_component.__file__
-    templates_dir = installed_location.replace("__init__.py", "")
-    template_path = Path(templates_dir) / "templates"
-    # typer.echo(template_path)
-
-    from jinja2 import Environment, FileSystemLoader
-
-    loader = FileSystemLoader(template_path)
-    jinja_environment = Environment(loader=loader)
-    index_template = jinja_environment.get_template("index.js.j2")
-    index_output = index_template.render({"ComponentName": name})
-
-    with open(f"{new_directory}/index.js", "w") as f:
-        f.write(index_output)
-
-    component_template = jinja_environment.get_template("component.js.j2")
-    component_output = component_template.render({"ComponentName": name})
-
-    with open(f"{new_directory}/{name}.js", "w") as f:
-        f.write(component_output)
+    # Echo status to user
+    _create_new_component_echo(
+        component_name=name,
+        full_path_to_component_directory=full_path_to_component_directory,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ show_error_codes = true
 
 [tool.poetry]
 name = "new-component"
-version = "0.1.1"
+version = "0.2.0"
 description = "Quickly create opinionated Styled Components for React Projects"
 authors = ["Ian Cleary <contact@iancleary.me>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ show_error_codes = true
 [tool.poetry]
 name = "new-component"
 version = "0.1.1"
-description = "Quickly create opinionated Sytled Components for React Projects"
+description = "Quickly create opinionated Styled Components for React Projects"
 authors = ["Ian Cleary <contact@iancleary.me>"]
 license = "MIT"
 homepage = "https://github.com/iancleary/new-component"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,6 @@
 from new_component import __version__, package_version
 
-current_version = "0.1.1"
+current_version = "0.2.0"
 
 
 def test_package_version() -> None:


### PR DESCRIPTION
## Description

The commits in this pull request will refactor the internals of the CLI to make the App internals modular and easier to reason about.

## Changes

- [`c31572e` (#1)](https://github.com/iancleary/new-component/pull/1/commits/c31572ec5a352806a2b3821ea644dde7de9054c4) fixes a typo in the `pyproject.toml` file
- [`d6d3045` (#1)](https://github.com/iancleary/new-component/pull/1/commits/d6d304539ca8df0bd6e091d0e4d3d9d4eb80f4d5) refactors the app's functions into submodules
- [`d538b5d` (#1)](https://github.com/iancleary/new-component/pull/1/commits/d538b5de7b15c72df27c37a1583f08b63b05e8af) adds the option to specify the file extension used, with `js` being the default.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
