### PR TITLE
Refactor typer confirms and echos into python modules

### DIFF
--- a/new_component/_confirms.py
+++ b/new_component/_confirms.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import typer
+
+
+def _create_components_dir_confirm(components_directory: Path) -> None:
+    styled_component_directory = typer.style(
+        f"./{components_directory}/", typer.colors.YELLOW, bold=True
+    )
+    confirm_message = (
+        styled_component_directory + " doesn't exist. Do you want to create it?"
+    )
+    typer.confirm(confirm_message, abort=True)
+
+
+def _overwrite_component_confirm(component_name: str) -> None:
+    styled_component = typer.style(f"{component_name}", typer.colors.YELLOW, bold=True)
+    confirm_message = (
+        "Are you sure you want to overwrite your " + styled_component + " component?"
+    )
+    typer.confirm(confirm_message, abort=True)

--- a/new_component/_echos.py
+++ b/new_component/_echos.py
@@ -4,24 +4,62 @@ import typer
 
 
 def _create_new_component_echo(
-    component_name: str, full_path_to_component_directory: Path
+    component_name: str, path_to_component_directory: Path
 ) -> None:
     """
     Echos the newly created component and directory.
     """
 
-    message_start = "Created a new "
-    component = typer.style(component_name, fg=typer.colors.GREEN, bold=True)
-    message_end = " Component 💅 🚀!"
-    new_directory_path = typer.style(
-        full_path_to_component_directory, fg=typer.colors.GREEN, bold=True
-    )
+    typer.echo("")
+    message_start = "✨ Creating a new "
+    component = typer.style(component_name, fg=typer.colors.YELLOW, bold=True)
+    message_end = " Component ✨!"
     message = message_start + component + message_end
     typer.echo(message)
-    typer.echo(new_directory_path)
+    typer.echo("")
+
+    new_directory_path = typer.style(
+        path_to_component_directory, fg=typer.colors.BLUE, bold=True
+    )
+    message = "Directory:".ljust(11) + new_directory_path
+    typer.echo(message)
+
+    styled_component = "styled 💅"
+    component_type = typer.style(styled_component, typer.colors.BLUE, bold=True)
+    message = "Type:".ljust(11) + component_type
+    typer.echo(message)
+
+    created_messages = [
+        "Directory created.",
+        f"{component_name} component created and saved to disk.",
+        "Index file created and saved to disk.",
+    ]
+
+    typer.echo("")
+    for created_message in created_messages:
+        typer.echo("✅ " + created_message)
+    typer.echo("")
+
+    component_type = typer.style(component_name, typer.colors.GREEN, bold=True)
+    message = component_type + " component created! 🚀"
+    typer.echo(message)
+
+    message = "Thank you for using new-component"
+
+    thank_you_message = typer.style(message, typer.colors.BRIGHT_BLACK)
+    typer.echo(thank_you_message)
+    typer.echo("")
 
 
 def _create_components_dir_echo(components_directory: Path) -> None:
     message = f"Warning: created the {components_directory} directory."
     styled_message = typer.style(message, fg=typer.colors.YELLOW, bold=True)
     typer.echo(styled_message)
+
+
+def _overwrite_component_echo(components_directory: Path, component_name: str) -> None:
+    warning_message = (
+        f"{component_name} component already exists in ./{components_directory}/."
+    )
+    styled_warning = typer.style(warning_message, typer.colors.YELLOW, bold=True)
+    typer.echo(styled_warning)

--- a/new_component/cli.py
+++ b/new_component/cli.py
@@ -3,7 +3,15 @@ from typing import Optional
 
 import typer
 
-from new_component._echos import _create_components_dir_echo, _create_new_component_echo
+from new_component._confirms import (
+    _create_components_dir_confirm,
+    _overwrite_component_confirm,
+)
+from new_component._echos import (
+    _create_components_dir_echo,
+    _create_new_component_echo,
+    _overwrite_component_echo,
+)
 from new_component._jinja import _create_jinja_environment
 from new_component._utils import _create_directory
 from new_component._version import _version_callback
@@ -72,39 +80,27 @@ def main(
 
     components_directory = Path(directory)
 
+    # Prompt user to create components directory, if it doesn't exist
     if components_directory.exists() is False:
-        # Could set creation with a variable
-        styled_component_directory = typer.style(
-            f"./{components_directory}/", typer.colors.YELLOW, bold=True
-        )
-        confirm_message = (
-            styled_component_directory + " doesn't exist. Do you want to create it?"
-        )
-        typer.confirm(confirm_message, abort=True)
+        _create_components_dir_confirm(components_directory=components_directory)
         _create_directory(directory=components_directory)
         _create_components_dir_echo(components_directory=components_directory)
 
+    # Create Paths to the new Component directory
     new_component_directory = components_directory / name
     full_path_to_component_directory = Path.cwd() / new_component_directory
 
-    # Allow user to abort if component already exists
+    # Allow user to abort if component already exists, else create component directory
     if full_path_to_component_directory.exists() is True:
-        warning_message = (
-            f"{name} component already exists in ./{components_directory}/."
+        _overwrite_component_echo(
+            components_directory=new_component_directory, component_name=name
         )
-        styled_warning = typer.style(warning_message, typer.colors.YELLOW, bold=True)
-        styled_component = typer.style(f"{name}", typer.colors.YELLOW, bold=True)
-        confirm_message = (
-            "Are you sure you want to overwrite your "
-            + styled_component
-            + " component?"
-        )
-        typer.echo(styled_warning)
-        typer.confirm(confirm_message, abort=True)
+        _overwrite_component_confirm(component_name=name)
+
     else:
         _create_directory(directory=full_path_to_component_directory)
 
-    # Jinja Variables used in template render
+    # Setup Jinja Variables used in template render
     variables = {"ComponentName": name}
 
     # Render component files in your components directory
@@ -122,8 +118,8 @@ def main(
         filename=f"{name}",
     )
 
-    # Echo status to user
+    # Echo final status to user
     _create_new_component_echo(
         component_name=name,
-        full_path_to_component_directory=full_path_to_component_directory,
+        path_to_component_directory=new_component_directory,
     )


### PR DESCRIPTION
## Description

This repository needs organization of typer echos and confirm prompts to make the main function more readable.

The commits in this pull request will move several sections of echos and confirms into `_echos.py` (exists) and `_confirms.py` (new), respectively

## Changes

- https://github.com/iancleary/new-component/pull/5/commits/01a9de8b0eb41fa89200be0a031d3c613af65ad3 move several sections of echos and confirms into `_echos.py` (exists) and `_confirms.py` (new), respectively

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
