### PR TITLE
Add src/new_components/templates/**.j2 to tool.pdm.build includes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ write_template = "__version__ = '{}'"  # optional, default to "{}"
 
 [tool.pdm.build]
 package-dir = "src"
-includes = ["src/new_component"]
+includes = ["src/new_component", "src/new_component/templates/**.j2"]
 source-includes = ["tests", "LICENSE", "README.md"]
 
 [tool.pdm.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "new_component"
-version = "0.4.3"
+version = "0.4.4"
 description = "Quickly create opinionated Styled Components for React Projects"
 authors = [
     {name = "Ian Cleary", email = "github@iancleary.me"},


### PR DESCRIPTION
## Description

This repository needs to have the templates sub-directory included in the build output

The commits in this pull request will add `src/new_components/templates/**.j2` to the `[tool.pdm.build]` `includes` list.


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
